### PR TITLE
Hackathon docker changes

### DIFF
--- a/cheri-hackathon/README.md
+++ b/cheri-hackathon/README.md
@@ -60,6 +60,18 @@ Run CHERI OS in Qemu:
 build-scripts/run-cheri.sh
 ```
 
+### Try the CHERI OS alice bob demo
+
+Read instructions in cheri-repos/cherios/demos/alice_bob/README.txt. CheriOS has been setup to run this demo automatically when it boots.
+
+Running cherios with
+
+```bash
+cheribuild.py run-cherios
+```
+
+Will allow you to iterate a little faster than using the wrapper script.
+
 ### Start hacking
 TODO: Description of what we need to build is here. \
 TODO: Add some links.

--- a/cheri-hackathon/build-scripts/Dockerfile
+++ b/cheri-hackathon/build-scripts/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
         gcc \
         g++ \
         libtool \
+	python3-pip \
         && \
     # Installing Clang:
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
@@ -38,7 +39,7 @@ RUN apt-get update && \
     apt-get install -y clang-8 lld-8 && \
     # Creating a marker file to easily detect that we're inside docker container:
     touch /.dev-env
-
+RUN pip3 install pyelftools argcomplete
 ## Setting up user/group which matches the user on the host:
 ARG USER=dev
 ARG USER_ID
@@ -53,5 +54,6 @@ ENV HOME=/home/${USER}
 WORKDIR ${HOME}
 
 ## Add stuff here
-
+COPY cheribuild.json ${HOME}/.config/cheribuild.json
+ENV PATH=${PATH}:${HOME}/workdir/cheri-repos/cheribuild
 WORKDIR ${HOME}/workdir

--- a/cheri-hackathon/build-scripts/build-cheri-sdk.sh
+++ b/cheri-hackathon/build-scripts/build-cheri-sdk.sh
@@ -10,9 +10,8 @@ $THIS_SCRIPT_DIR/checkout-cheri-repos.sh
 
 echo ===== Building CHERI SDK =====
 cd $CHERI_REPOS_DIR/cheribuild
-./cheribuild.py --source-root $CHERI_REPOS_DIR --output-root $REPO_DIR freestanding-sdk
-./cheribuild.py bmake --source-root $CHERI_REPOS_DIR --output-root $REPO_DIR freestanding-sdk
-./cheribuild.py cherios -d --source-root $CHERI_REPOS_DIR --output-root $REPO_DIR freestanding-sdk
+./cheribuild.py bmake freestanding-sdk
+./cheribuild.py cherios -d
 
 # Creating file with git revision information to identify the build origin
 for repo in `ls -d $CHERI_REPOS_DIR/*/.git`; do (

--- a/cheri-hackathon/build-scripts/cheribuild.json
+++ b/cheri-hackathon/build-scripts/cheribuild.json
@@ -1,0 +1,11 @@
+{
+	"source-root": "${HOME}/workdir/cheri-repos",
+	"build-root": "${HOME}/workdir/cheri-repos/build",
+	"output-root": "${HOME}/workdir",
+	"llvm": {
+		"debug-info": false
+	},
+	"cherios-llvm": {
+		"debug-info": false
+	}
+}

--- a/cheri-hackathon/build-scripts/run-cherios.sh
+++ b/cheri-hackathon/build-scripts/run-cherios.sh
@@ -7,7 +7,7 @@ CHERI_REPOS_DIR=$REPO_DIR/cheri-repos
 
 echo ===== Running CHERI OS =====
 cd $CHERI_REPOS_DIR/cheribuild
-./cheribuild.py run-cherios -d --source-root $CHERI_REPOS_DIR --output-root $REPO_DIR freestanding-sdk
+./cheribuild.py run-cherios -d
 
 # Creating file with git revision information to identify the build origin
 for repo in `ls -d $CHERI_REPOS_DIR/*/.git`; do (


### PR DESCRIPTION
A few changes:

I have added a cheribuild config file to replace the add hoc use of variables in build scripts and allow the use of cheribuild directly. This should hopefully keep configuration consistent. It also disables debug symbols for building llvm, which should hopefully allow people to build an SDK much faster, although I would strongly suggest building before attending the hackathon.

I have added python dependency to the docker image that CheriOS needs to build the demo.

I have added some top level instructions on where to find the CheriOS demo.